### PR TITLE
Fix I2C issues with Raspberry Pi 2

### DIFF
--- a/controller/usitwislave.c
+++ b/controller/usitwislave.c
@@ -11,32 +11,32 @@
 
 enum
 {
-	of_state_check_address,
-	of_state_send_data,
-	of_state_request_ack,
-	of_state_check_ack,
-	of_state_receive_data,
-	of_state_store_data_and_send_ack
+  of_state_check_address,
+  of_state_send_data,
+  of_state_request_ack,
+  of_state_check_ack,
+  of_state_receive_data,
+  of_state_store_data_and_send_ack
 } overflow_state_t;
 
 enum
 {
-	ss_state_before_start,
-	ss_state_after_start,
-	ss_state_address_selected,
-	ss_state_address_not_selected,
-	ss_state_data_processed
+  ss_state_before_start,
+  ss_state_after_start,
+  ss_state_address_selected,
+  ss_state_address_not_selected,
+  ss_state_data_processed
 } startstop_state_t;
 
 enum
 {
-	buffer_size = 32
+  buffer_size = 32
 };
 
 static void (*idle_callback)(void);
 static void	(*data_callback)(uint8_t buffer_size,
-						uint8_t volatile input_buffer_length, const volatile uint8_t *input_buffer,
-						uint8_t volatile *output_buffer_length, uint8_t volatile *output_buffer);
+                             uint8_t volatile input_buffer_length, const volatile uint8_t *input_buffer,
+                             uint8_t volatile *output_buffer_length, uint8_t volatile *output_buffer);
 
 static volatile	uint8_t of_state;
 static volatile uint8_t ss_state;
@@ -59,395 +59,403 @@ static volatile uint16_t	idle_call_count;
 
 static always_inline void set_sda_to_input(void)
 {
-	DDR_USI &= ~_BV(PORT_USI_SDA);
+  DDR_USI &= ~_BV(PORT_USI_SDA);
 }
 
 static always_inline void set_sda_to_output(void)
 {
-	DDR_USI |= _BV(PORT_USI_SDA);
+  DDR_USI |= _BV(PORT_USI_SDA);
 }
 
 static always_inline void set_scl_to_input(void)
 {
-	DDR_USI &= ~_BV(PORT_USI_SCL);
+  DDR_USI &= ~_BV(PORT_USI_SCL);
 }
 
 static always_inline void set_scl_to_output(void)
 {
-	DDR_USI |= _BV(PORT_USI_SCL);
+  DDR_USI |= _BV(PORT_USI_SCL);
 }
 
 static always_inline void set_sda_low(void)
 {
-	PORT_USI &= ~_BV(PORT_USI_SDA);
+  PORT_USI &= ~_BV(PORT_USI_SDA);
 }
 
 static always_inline void set_sda_high(void)
 {
-	PORT_USI |= _BV(PORT_USI_SDA);
+  PORT_USI |= _BV(PORT_USI_SDA);
 }
 
 static always_inline void set_scl_low(void)
 {
-	PORT_USI &= ~_BV(PORT_USI_SCL);
+  PORT_USI &= ~_BV(PORT_USI_SCL);
 }
 
 static always_inline void set_scl_high(void)
 {
-	PORT_USI |= _BV(PORT_USI_SCL);
+  PORT_USI |= _BV(PORT_USI_SCL);
 }
 
 static always_inline void twi_reset_state(void)
 {
-	USISR =
-		(1		<< USISIF)	|		// clear start condition flag
-		(1		<< USIOIF)	|		// clear overflow condition flag
-		(0		<< USIPF)	|		// don't clear stop condition flag
-		(1		<< USIDC)	|		// clear arbitration error flag
-		(0x00	<< USICNT0);		// set counter to "8" bits
+  USISR =
+  (1		<< USISIF)	|		// clear start condition flag
+  (1		<< USIOIF)	|		// clear overflow condition flag
+  (0		<< USIPF)	|		// don't clear stop condition flag
+  (1		<< USIDC)	|		// clear arbitration error flag
+  (0x00	<< USICNT0);		// set counter to "8" bits
 
-	USICR =
-		(1 << USISIE) |									// enable start condition interrupt
-		(0 << USIOIE) |									// disable overflow interrupt
-		(1 << USIWM1) | (0 << USIWM0) |					// set usi in two-wire mode, disable bit counter overflow hold
-		(1 << USICS1) | (0 << USICS0) | (0 << USICLK) |	// shift register clock source = external, positive edge, 4-bit counter source = external, both edges
-		(0 << USITC);									// don't toggle clock-port pin
+  USICR =
+  (1 << USISIE) |									// enable start condition interrupt
+  (0 << USIOIE) |									// disable overflow interrupt
+  (1 << USIWM1) | (0 << USIWM0) |					// set usi in two-wire mode, disable bit counter overflow hold
+  (1 << USICS1) | (0 << USICS0) | (0 << USICLK) |	// shift register clock source = external, positive edge, 4-bit counter source = external, both edges
+  (0 << USITC);									// don't toggle clock-port pin
 }
 
 static always_inline void twi_reset(void)
 {
-	// make sure no sda/scl remains pulled up or down
+  // make sure no sda/scl remains pulled up or down
 
-	set_sda_to_input();		//	deactivate internal pullup on sda/scl
-	set_sda_low();
-	set_scl_to_input();
-	set_scl_low();
+  set_sda_to_input();		//	deactivate internal pullup on sda/scl
+  set_sda_low();
+  set_scl_to_input();
+  set_scl_low();
 
-	set_sda_to_output();	//	release (set high) on sda/scl
-	set_sda_high();
-	set_sda_to_input();
-	set_scl_to_output();
-	set_scl_high();
+  set_sda_to_output();	//	release (set high) on sda/scl
+  set_sda_high();
+  set_sda_to_input();
+  set_scl_to_output();
+  set_scl_high();
 
-	twi_reset_state();
+  twi_reset_state();
 }
 
 static always_inline void twi_init(void)
 {
-#if defined(USIPP)
-#if  defined(USI_ON_PORT_A)
-	USIPP |= _BV(USIPOS);
-#else
-	USIPP &= ~_BV(USIPOS);
-# endif
-#endif
+  #if defined(USIPP)
+  #if  defined(USI_ON_PORT_A)
+  USIPP |= _BV(USIPOS);
+  #else
+  USIPP &= ~_BV(USIPOS);
+  # endif
+  #endif
 
-	twi_reset();
+  twi_reset();
 }
 
 ISR(USI_START_vect)
 {
-	set_sda_to_input();
+  set_sda_to_input();
 
-	// wait for SCL to go low to ensure the start condition has completed (the
-	// start detector will hold SCL low) - if a stop condition arises then leave
-	// the interrupt to prevent waiting forever - don't use USISR to test for stop
-	// condition as in Application Note AVR312 because the stop condition Flag is
-	// going to be set from the last TWI sequence
+  // wait for SCL to go low to ensure the start condition has completed (the
+  // start detector will hold SCL low) - if a stop condition arises then leave
+  // the interrupt to prevent waiting forever - don't use USISR to test for stop
+  // condition as in Application Note AVR312 because the stop condition Flag is
+  // going to be set from the last TWI sequence
 
-	while(!(PIN_USI & _BV(PIN_USI_SDA)) &&
-			(PIN_USI & _BV(PIN_USI_SCL)))
+  while(!(PIN_USI & _BV(PIN_USI_SDA)) &&
+    (PIN_USI & _BV(PIN_USI_SCL)))
 
-	// possible combinations
-	//	sda = low	scl = low		break	start condition
-	// 	sda = low	scl = high		loop
-	//	sda = high	scl = low		break	stop condition
-	//	sda = high	scl = high		break	stop condition
+    // possible combinations
+    //	sda = low	scl = low		break	start condition
+    // 	sda = low	scl = high		loop
+    //	sda = high	scl = low		break	stop condition
+    //	sda = high	scl = high		break	stop condition
 
-	if((PIN_USI & _BV(PIN_USI_SDA)))	// stop condition
-	{
-		twi_reset();
+    if((PIN_USI & _BV(PIN_USI_SDA)))	// stop condition
+    {
+      twi_reset();
 
-		if(stats_enabled)
-			error_conditions_count++;
-		return;
-	}
+      if(stats_enabled)
+        error_conditions_count++;
+      return;
+    }
 
-	if(stats_enabled)
-		start_conditions_count++;
+    if(stats_enabled)
+      start_conditions_count++;
 
-	of_state = of_state_check_address;
-	ss_state = ss_state_after_start;
+    of_state = of_state_check_address;
+    ss_state = ss_state_after_start;
 
-	USIDR = 0xff;
+    USIDR = 0xff;
 
-	USICR =
-		(1 << USISIE) |									// enable start condition interrupt
-		(1 << USIOIE) |									// enable overflow interrupt
-		(1 << USIWM1) | (1 << USIWM0) |					// set usi in two-wire mode, enable bit counter overflow hold
-		(1 << USICS1) | (0 << USICS0) | (0 << USICLK) |	// shift register clock source = external, positive edge, 4-bit counter source = external, both edges
-		(0 << USITC);									// don't toggle clock-port pin
+    USICR =
+    (1 << USISIE) |									// enable start condition interrupt
+    (1 << USIOIE) |									// enable overflow interrupt
+    (1 << USIWM1) | (1 << USIWM0) |					// set usi in two-wire mode, enable bit counter overflow hold
+    (1 << USICS1) | (0 << USICS0) | (0 << USICLK) |	// shift register clock source = external, positive edge, 4-bit counter source = external, both edges
+    (0 << USITC);									// don't toggle clock-port pin
 
-	USISR =
-		(1		<< USISIF)	|		// clear start condition flag
-		(1		<< USIOIF)	|		// clear overflow condition flag
-		(0		<< USIPF)	|		// don't clear stop condition flag
-		(1		<< USIDC)	|		// clear arbitration error flag
-		(0x00	<< USICNT0);		// set counter to "8" bits
+    USISR =
+    (1		<< USISIF)	|		// clear start condition flag
+    (1		<< USIOIF)	|		// clear overflow condition flag
+    (0		<< USIPF)	|		// don't clear stop condition flag
+    (1		<< USIDC)	|		// clear arbitration error flag
+    (0x00	<< USICNT0);		// set counter to "8" bits
 }
 
 ISR(USI_OVERFLOW_VECTOR)
 {
-	// bit shift register overflow condition occured
-	// scl forced low until overflow condition is cleared!
+  // bit shift register overflow condition occured
+  // scl forced low until overflow condition is cleared!
 
-	uint8_t data		= USIDR;
-	uint8_t set_counter = 0x00;		// send 8 bits (16 edges)
+  uint8_t data		= USIDR;
+  uint8_t set_counter = 0x00;		// send 8 bits (16 edges)
 
-	if(stats_enabled)
-		overflow_conditions_count++;
+  if(stats_enabled)
+    overflow_conditions_count++;
 
-again:
-	switch(of_state)
-	{
-		// start condition occured and succeed
-		// check address, if not OK, reset usi
-		// note: not using general call address
+  again:
+  switch(of_state)
+  {
+    // start condition occured and succeed
+    // check address, if not OK, reset usi
+    // note: not using general call address
 
-		case(of_state_check_address):
-		{
-			uint8_t address;
-			uint8_t direction;
+    case(of_state_check_address):
+    {
+      uint8_t address;
+      uint8_t direction;
 
-			direction	= data & 0x01;
-			address		= (data & 0xfe) >> 1;
+      direction	= data & 0x01;
+      address		= (data & 0xfe) >> 1;
 
-			if(address == slave_address)
-			{
-				ss_state = ss_state_address_selected;
+      if(address == slave_address)
+      {
+        ss_state = ss_state_address_selected;
 
-				if(direction)					// read request from master
-					of_state = of_state_send_data;
-				else							// write request from master
-					of_state = of_state_receive_data;
+        if(direction)					// read request from master
+          of_state = of_state_send_data;
+        else							// write request from master
+          of_state = of_state_receive_data;
 
-				USIDR		= 0x00;
-				set_counter = 0x0e;				// send 1 bit (2 edges)
-				set_sda_to_output();			// initiate send ack
-			}
-			else
-			{
-				USIDR		= 0x00;
-				set_counter = 0x00;
-				twi_reset_state();
-				ss_state = ss_state_address_not_selected;
-			}
+        USIDR		= 0x00;
+        set_counter = 0x0e;				// send 1 bit (2 edges)
+        set_sda_to_output();			// initiate send ack
+      }
+      else
+      {
+        USIDR		= 0x00;
+        set_counter = 0x00;
+        twi_reset_state();
+        ss_state = ss_state_address_not_selected;
+      }
 
-			break;
-		}
+      break;
+    }
 
-		// process read request from master
+    // process read request from master
 
-		case(of_state_send_data):
-		{
-			ss_state = ss_state_data_processed;
-			of_state = of_state_request_ack;
+    case(of_state_send_data):
+    {
+      ss_state = ss_state_data_processed;
+      of_state = of_state_request_ack;
 
-			if(output_buffer_current < output_buffer_length)
-				USIDR = output_buffer[output_buffer_current++];
-			else
-				USIDR = 0xfe;
+      if(output_buffer_current < output_buffer_length)
+        USIDR = output_buffer[output_buffer_current++];
+      else
+        USIDR = 0xfe;
 
-			set_counter = 0x00;
-			set_sda_to_output();				// initiate send data
+      set_counter = 0x00;
+      set_sda_to_output();				// initiate send data
 
-			break;
-		}
+      break;
+    }
 
-		// data sent to master, request ack (or nack) from master
+    // data sent to master, request ack (or nack) from master
 
-		case(of_state_request_ack):
-		{
-			of_state = of_state_check_ack;
+    case(of_state_request_ack):
+    {
+      of_state = of_state_check_ack;
 
-			USIDR		= 0x00;
-			set_counter = 0x0e;					//	receive 1 bit (2 edges)
-			set_sda_to_input();					//	initiate receive ack
+      USIDR		= 0x00;
+      set_counter = 0x0e;					//	receive 1 bit (2 edges)
+      set_sda_to_input();					//	initiate receive ack
 
-			break;
-		}
+      break;
+    }
 
-		// ack/nack from master received
+    // ack/nack from master received
 
-		case(of_state_check_ack):
-		{
-			if(data)	// if NACK, the master does not want more data
-			{
-				of_state = of_state_check_address;
-				set_counter = 0x00;
-				twi_reset();
-			}
-			else
-			{
-				of_state = of_state_send_data;
-				goto again;	// from here we just drop straight into state_send_data
-			}				// don't wait for another overflow interrupt
+    case(of_state_check_ack):
+    {
+      if(data)	// if NACK, the master does not want more data
+      {
+        of_state = of_state_check_address;
+        set_counter = 0x00;
+        twi_reset();
+      }
+      else
+      {
+        of_state = of_state_send_data;
+        goto again;	// from here we just drop straight into state_send_data
+      }				// don't wait for another overflow interrupt
 
-			break;
-		}
+      break;
+    }
 
-		// process write request from master
+    // process write request from master
 
-		case(of_state_receive_data):
-		{
-			ss_state = ss_state_data_processed;
+    case(of_state_receive_data):
+    {
+      ss_state = ss_state_data_processed;
 
-			of_state = of_state_store_data_and_send_ack;
+      of_state = of_state_store_data_and_send_ack;
 
-			set_counter = 0x00;					// receive 1 bit (2 edges)
-			set_sda_to_input();					// initiate receive data
+      set_counter = 0x00;					// receive 1 bit (2 edges)
+      set_sda_to_input();					// initiate receive data
 
-			break;
-		}
+      break;
+    }
 
-		// data received from master, store it and wait for more data
+    // data received from master, store it and wait for more data
 
-		case(of_state_store_data_and_send_ack):
-		{
-			of_state = of_state_receive_data;
+    case(of_state_store_data_and_send_ack):
+    {
+      of_state = of_state_receive_data;
 
-			if(input_buffer_length < (buffer_size - 1))
-				input_buffer[input_buffer_length++] = data;
+      if(input_buffer_length < (buffer_size - 1))
+        input_buffer[input_buffer_length++] = data;
 
-			USIDR		= 0x00;
-			set_counter = 0x0e;					// send 1 bit (2 edges)
-			set_sda_to_output();				// initiate send ack
+      USIDR		= 0x00;
+      set_counter = 0x0e;					// send 1 bit (2 edges)
+      set_sda_to_output();				// initiate send ack
 
-			break;
-		}
-	}
+      break;
+    }
+  }
 
-	USISR =
-		(0				<< USISIF)	|		// don't clear start condition flag
-		(1				<< USIOIF)	|		// clear overflow condition flag
-		(0				<< USIPF)	|		// don't clear stop condition flag
-		(1				<< USIDC)	|		// clear arbitration error flag
-		(set_counter	<< USICNT0);		// set counter to 8 or 1 bits
+  USISR =
+  (0				<< USISIF)	|		// don't clear start condition flag
+  (1				<< USIOIF)	|		// clear overflow condition flag
+  (0				<< USIPF)	|		// don't clear stop condition flag
+  (1				<< USIDC)	|		// clear arbitration error flag
+  (set_counter	<< USICNT0);		// set counter to 8 or 1 bits
 }
 
 void usi_twi_slave(uint8_t slave_address_in, uint8_t use_sleep,
-			void (*data_callback_in)(uint8_t buffer_size,
-			volatile uint8_t input_buffer_length, volatile const uint8_t *input_buffer,
-			volatile uint8_t *output_buffer_length, volatile uint8_t *output_buffer),
-			void (*idle_callback_in)(void))
+                   void (*data_callback_in)(uint8_t buffer_size,
+                                            volatile uint8_t input_buffer_length, volatile const uint8_t *input_buffer,
+                                            volatile uint8_t *output_buffer_length, volatile uint8_t *output_buffer),
+                   void (*idle_callback_in)(void))
 {
-	slave_address			= slave_address_in;
-	data_callback			= data_callback_in;
-	idle_callback			= idle_callback_in;
+  slave_address			= slave_address_in;
+  data_callback			= data_callback_in;
+  idle_callback			= idle_callback_in;
 
-	input_buffer_length		= 0;
-	output_buffer_length	= 0;
-	output_buffer_current	= 0;
-	ss_state				= ss_state_before_start;
+  input_buffer_length		= 0;
+  output_buffer_length	= 0;
+  output_buffer_current	= 0;
+  ss_state				= ss_state_before_start;
 
-	if(use_sleep)
-		set_sleep_mode(SLEEP_MODE_IDLE);
+  if(use_sleep)
+    set_sleep_mode(SLEEP_MODE_IDLE);
 
-	twi_init();
+  twi_init();
 
-	sei();
+  sei();
 
-	for(;;)
-	{
-		if(use_sleep && (ss_state == ss_state_before_start))
-			sleep_mode();
+  for(;;)
+  {
+    if(use_sleep && (ss_state == ss_state_before_start))
+      sleep_mode();
 
-		if(USISR & _BV(USIPF))
-		{
-			cli();
+    /*
+     * This library cannot detect repeated starts and will execute the callback only
+     * after a stop condition.
+     *
+     * Start processing when there is a byte in the input buffer
+     *
+     * WARNING: This means that we process data after one byte sent on I2C!
+     */
+    if((USISR & _BV(USIPF)) || (input_buffer_length > 0))
+    {
+      cli();
 
-			if(stats_enabled)
-				stop_conditions_count++;
+      if(stats_enabled)
+        stop_conditions_count++;
 
-			USISR |= _BV(USIPF);	// clear stop condition flag
+      USISR |= _BV(USIPF);	// clear stop condition flag
 
-			switch(ss_state)
-			{
-				case(ss_state_after_start):
-				{
-					twi_reset();
-					break;
-				}
+      switch(ss_state)
+      {
+        case(ss_state_after_start):
+        {
+          twi_reset();
+          break;
+        }
 
-				case(ss_state_data_processed):
-				{
-					if(stats_enabled)
-						local_frames_count++;
+        case(ss_state_data_processed):
+        {
+          if(stats_enabled)
+            local_frames_count++;
 
-					output_buffer_length	= 0;
-					output_buffer_current	= 0;
+          output_buffer_length	= 0;
+          output_buffer_current	= 0;
 
-					data_callback(buffer_size, input_buffer_length, input_buffer, &output_buffer_length, output_buffer);
+          data_callback(buffer_size, input_buffer_length, input_buffer, &output_buffer_length, output_buffer);
 
-					input_buffer_length		= 0;
+          input_buffer_length		= 0;
 
-					break;
-				}
+          break;
+        }
 
-			}
+      }
 
-			ss_state = ss_state_before_start;
+      ss_state = ss_state_before_start;
 
-			sei();
-		}
+      sei();
+    }
 
-		if(idle_callback)
-		{
-			idle_callback();
+    if(idle_callback)
+    {
+      idle_callback();
 
-			if(stats_enabled)
-				idle_call_count++;
-		}
-	}
+      if(stats_enabled)
+        idle_call_count++;
+    }
+  }
 }
 
 void usi_twi_enable_stats(uint8_t onoff)
 {
-	stats_enabled				= onoff;
-	start_conditions_count		= 0;
-	stop_conditions_count		= 0;
-	error_conditions_count		= 0;
-	overflow_conditions_count	= 0;
-	local_frames_count			= 0;
-	idle_call_count				= 0;
+  stats_enabled				= onoff;
+  start_conditions_count		= 0;
+  stop_conditions_count		= 0;
+  error_conditions_count		= 0;
+  overflow_conditions_count	= 0;
+  local_frames_count			= 0;
+  idle_call_count				= 0;
 }
 
 uint16_t usi_twi_stats_start_conditions(void)
 {
-	return(start_conditions_count);
+  return(start_conditions_count);
 }
 
 uint16_t usi_twi_stats_stop_conditions(void)
 {
-	return(stop_conditions_count);
+  return(stop_conditions_count);
 }
 
 uint16_t usi_twi_stats_error_conditions(void)
 {
-	return(error_conditions_count);
+  return(error_conditions_count);
 }
 
 uint16_t usi_twi_stats_overflow_conditions(void)
 {
-	return(overflow_conditions_count);
+  return(overflow_conditions_count);
 }
 
 uint16_t usi_twi_stats_local_frames(void)
 {
-	return(local_frames_count);
+  return(local_frames_count);
 }
 
 uint16_t usi_twi_stats_idle_calls(void)
 {
-	return(idle_call_count);
+  return(idle_call_count);
 }

--- a/controller/usitwislave.h
+++ b/controller/usitwislave.h
@@ -6,10 +6,10 @@
 #define	_USI_TWI_SLAVE_H_
 
 void		usi_twi_slave(uint8_t slave_address, uint8_t use_sleep,
-				void (*data_callback)(uint8_t buffer_size,
-				volatile uint8_t input_buffer_length, volatile const uint8_t *input_buffer,
-				volatile uint8_t *output_buffer_length, volatile uint8_t *output_buffer),
-				void (*idle_callback)(void));
+                      void (*data_callback)(uint8_t buffer_size,
+                                            volatile uint8_t input_buffer_length, volatile const uint8_t *input_buffer,
+                                            volatile uint8_t *output_buffer_length, volatile uint8_t *output_buffer),
+                    void (*idle_callback)(void));
 
 void		usi_twi_enable_stats(uint8_t onoff);
 uint16_t	usi_twi_stats_start_conditions(void);

--- a/controller/usitwislave_devices.h
+++ b/controller/usitwislave_devices.h
@@ -12,8 +12,8 @@
 #endif
 
 #if		defined(__AVR_ATtiny24__) | \
-		defined(__AVR_ATtiny44__) | \
-		defined(__AVR_ATtiny84__)
+defined(__AVR_ATtiny44__) | \
+defined(__AVR_ATtiny84__)
 #	define DDR_USI				DDRA
 #	define PORT_USI				PORTA
 #	define PIN_USI				PINA
@@ -25,8 +25,8 @@
 #endif
 
 #if		defined(__AVR_ATtiny25__) | \
-		defined(__AVR_ATtiny45__) | \
-		defined(__AVR_ATtiny85__)
+defined(__AVR_ATtiny45__) | \
+defined(__AVR_ATtiny85__)
 #	define DDR_USI				DDRB
 #	define PORT_USI				PORTB
 #	define PIN_USI				PINB
@@ -49,11 +49,11 @@
 #endif
 
 #if		defined(__AVR_ATtiny261__) | \
-		defined(__AVR_ATtiny261a__) | \
-		defined(__AVR_ATtiny461__) | \
-		defined(__AVR_ATtiny461a__) | \
-		defined(__AVR_ATtiny861__) | \
-		defined(__AVR_ATtiny861a__)
+defined(__AVR_ATtiny261a__) | \
+defined(__AVR_ATtiny461__) | \
+defined(__AVR_ATtiny461a__) | \
+defined(__AVR_ATtiny861__) | \
+defined(__AVR_ATtiny861a__)
 #	if		defined(USI_ON_PORT_A)
 #		define DDR_USI				DDRA
 #		define PORT_USI				PORTA
@@ -75,12 +75,12 @@
 #endif
 
 #if		defined(__AVR_ATmega165__) | \
-		defined(__AVR_ATmega325__) | \
-		defined(__AVR_ATmega3250__) | \
-		defined(__AVR_ATmega645__) | \
-		defined(__AVR_ATmega6450__) | \
-		defined(__AVR_ATmega329__) | \
-		defined(__AVR_ATmega3290__)
+defined(__AVR_ATmega325__) | \
+defined(__AVR_ATmega3250__) | \
+defined(__AVR_ATmega645__) | \
+defined(__AVR_ATmega6450__) | \
+defined(__AVR_ATmega329__) | \
+defined(__AVR_ATmega3290__)
 #	define DDR_USI				DDRE
 #	define PORT_USI				PORTE
 #	define PIN_USI				PINE

--- a/manuellsteuerung/usitwislave.c
+++ b/manuellsteuerung/usitwislave.c
@@ -11,32 +11,32 @@
 
 enum
 {
-	of_state_check_address,
-	of_state_send_data,
-	of_state_request_ack,
-	of_state_check_ack,
-	of_state_receive_data,
-	of_state_store_data_and_send_ack
+  of_state_check_address,
+  of_state_send_data,
+  of_state_request_ack,
+  of_state_check_ack,
+  of_state_receive_data,
+  of_state_store_data_and_send_ack
 } overflow_state_t;
 
 enum
 {
-	ss_state_before_start,
-	ss_state_after_start,
-	ss_state_address_selected,
-	ss_state_address_not_selected,
-	ss_state_data_processed
+  ss_state_before_start,
+  ss_state_after_start,
+  ss_state_address_selected,
+  ss_state_address_not_selected,
+  ss_state_data_processed
 } startstop_state_t;
 
 enum
 {
-	buffer_size = 32
+  buffer_size = 32
 };
 
 static void (*idle_callback)(void);
 static void	(*data_callback)(uint8_t buffer_size,
-						uint8_t volatile input_buffer_length, const volatile uint8_t *input_buffer,
-						uint8_t volatile *output_buffer_length, uint8_t volatile *output_buffer);
+                             uint8_t volatile input_buffer_length, const volatile uint8_t *input_buffer,
+                             uint8_t volatile *output_buffer_length, uint8_t volatile *output_buffer);
 
 static volatile	uint8_t of_state;
 static volatile uint8_t ss_state;
@@ -59,395 +59,403 @@ static volatile uint16_t	idle_call_count;
 
 static always_inline void set_sda_to_input(void)
 {
-	DDR_USI &= ~_BV(PORT_USI_SDA);
+  DDR_USI &= ~_BV(PORT_USI_SDA);
 }
 
 static always_inline void set_sda_to_output(void)
 {
-	DDR_USI |= _BV(PORT_USI_SDA);
+  DDR_USI |= _BV(PORT_USI_SDA);
 }
 
 static always_inline void set_scl_to_input(void)
 {
-	DDR_USI &= ~_BV(PORT_USI_SCL);
+  DDR_USI &= ~_BV(PORT_USI_SCL);
 }
 
 static always_inline void set_scl_to_output(void)
 {
-	DDR_USI |= _BV(PORT_USI_SCL);
+  DDR_USI |= _BV(PORT_USI_SCL);
 }
 
 static always_inline void set_sda_low(void)
 {
-	PORT_USI &= ~_BV(PORT_USI_SDA);
+  PORT_USI &= ~_BV(PORT_USI_SDA);
 }
 
 static always_inline void set_sda_high(void)
 {
-	PORT_USI |= _BV(PORT_USI_SDA);
+  PORT_USI |= _BV(PORT_USI_SDA);
 }
 
 static always_inline void set_scl_low(void)
 {
-	PORT_USI &= ~_BV(PORT_USI_SCL);
+  PORT_USI &= ~_BV(PORT_USI_SCL);
 }
 
 static always_inline void set_scl_high(void)
 {
-	PORT_USI |= _BV(PORT_USI_SCL);
+  PORT_USI |= _BV(PORT_USI_SCL);
 }
 
 static always_inline void twi_reset_state(void)
 {
-	USISR =
-		(1		<< USISIF)	|		// clear start condition flag
-		(1		<< USIOIF)	|		// clear overflow condition flag
-		(0		<< USIPF)	|		// don't clear stop condition flag
-		(1		<< USIDC)	|		// clear arbitration error flag
-		(0x00	<< USICNT0);		// set counter to "8" bits
+  USISR =
+  (1		<< USISIF)	|		// clear start condition flag
+  (1		<< USIOIF)	|		// clear overflow condition flag
+  (0		<< USIPF)	|		// don't clear stop condition flag
+  (1		<< USIDC)	|		// clear arbitration error flag
+  (0x00	<< USICNT0);		// set counter to "8" bits
 
-	USICR =
-		(1 << USISIE) |									// enable start condition interrupt
-		(0 << USIOIE) |									// disable overflow interrupt
-		(1 << USIWM1) | (0 << USIWM0) |					// set usi in two-wire mode, disable bit counter overflow hold
-		(1 << USICS1) | (0 << USICS0) | (0 << USICLK) |	// shift register clock source = external, positive edge, 4-bit counter source = external, both edges
-		(0 << USITC);									// don't toggle clock-port pin
+  USICR =
+  (1 << USISIE) |									// enable start condition interrupt
+  (0 << USIOIE) |									// disable overflow interrupt
+  (1 << USIWM1) | (0 << USIWM0) |					// set usi in two-wire mode, disable bit counter overflow hold
+  (1 << USICS1) | (0 << USICS0) | (0 << USICLK) |	// shift register clock source = external, positive edge, 4-bit counter source = external, both edges
+  (0 << USITC);									// don't toggle clock-port pin
 }
 
 static always_inline void twi_reset(void)
 {
-	// make sure no sda/scl remains pulled up or down
+  // make sure no sda/scl remains pulled up or down
 
-	set_sda_to_input();		//	deactivate internal pullup on sda/scl
-	set_sda_low();
-	set_scl_to_input();
-	set_scl_low();
+  set_sda_to_input();		//	deactivate internal pullup on sda/scl
+  set_sda_low();
+  set_scl_to_input();
+  set_scl_low();
 
-	set_sda_to_output();	//	release (set high) on sda/scl
-	set_sda_high();
-	set_sda_to_input();
-	set_scl_to_output();
-	set_scl_high();
+  set_sda_to_output();	//	release (set high) on sda/scl
+  set_sda_high();
+  set_sda_to_input();
+  set_scl_to_output();
+  set_scl_high();
 
-	twi_reset_state();
+  twi_reset_state();
 }
 
 static always_inline void twi_init(void)
 {
-#if defined(USIPP)
-#if  defined(USI_ON_PORT_A)
-	USIPP |= _BV(USIPOS);
-#else
-	USIPP &= ~_BV(USIPOS);
-# endif
-#endif
+  #if defined(USIPP)
+  #if  defined(USI_ON_PORT_A)
+  USIPP |= _BV(USIPOS);
+  #else
+  USIPP &= ~_BV(USIPOS);
+  # endif
+  #endif
 
-	twi_reset();
+  twi_reset();
 }
 
 ISR(USI_START_vect)
 {
-	set_sda_to_input();
+  set_sda_to_input();
 
-	// wait for SCL to go low to ensure the start condition has completed (the
-	// start detector will hold SCL low) - if a stop condition arises then leave
-	// the interrupt to prevent waiting forever - don't use USISR to test for stop
-	// condition as in Application Note AVR312 because the stop condition Flag is
-	// going to be set from the last TWI sequence
+  // wait for SCL to go low to ensure the start condition has completed (the
+  // start detector will hold SCL low) - if a stop condition arises then leave
+  // the interrupt to prevent waiting forever - don't use USISR to test for stop
+  // condition as in Application Note AVR312 because the stop condition Flag is
+  // going to be set from the last TWI sequence
 
-	while(!(PIN_USI & _BV(PIN_USI_SDA)) &&
-			(PIN_USI & _BV(PIN_USI_SCL)))
+  while(!(PIN_USI & _BV(PIN_USI_SDA)) &&
+    (PIN_USI & _BV(PIN_USI_SCL)))
 
-	// possible combinations
-	//	sda = low	scl = low		break	start condition
-	// 	sda = low	scl = high		loop
-	//	sda = high	scl = low		break	stop condition
-	//	sda = high	scl = high		break	stop condition
+    // possible combinations
+    //	sda = low	scl = low		break	start condition
+    // 	sda = low	scl = high		loop
+    //	sda = high	scl = low		break	stop condition
+    //	sda = high	scl = high		break	stop condition
 
-	if((PIN_USI & _BV(PIN_USI_SDA)))	// stop condition
-	{
-		twi_reset();
+    if((PIN_USI & _BV(PIN_USI_SDA)))	// stop condition
+    {
+      twi_reset();
 
-		if(stats_enabled)
-			error_conditions_count++;
-		return;
-	}
+      if(stats_enabled)
+        error_conditions_count++;
+      return;
+    }
 
-	if(stats_enabled)
-		start_conditions_count++;
+    if(stats_enabled)
+      start_conditions_count++;
 
-	of_state = of_state_check_address;
-	ss_state = ss_state_after_start;
+    of_state = of_state_check_address;
+    ss_state = ss_state_after_start;
 
-	USIDR = 0xff;
+    USIDR = 0xff;
 
-	USICR =
-		(1 << USISIE) |									// enable start condition interrupt
-		(1 << USIOIE) |									// enable overflow interrupt
-		(1 << USIWM1) | (1 << USIWM0) |					// set usi in two-wire mode, enable bit counter overflow hold
-		(1 << USICS1) | (0 << USICS0) | (0 << USICLK) |	// shift register clock source = external, positive edge, 4-bit counter source = external, both edges
-		(0 << USITC);									// don't toggle clock-port pin
+    USICR =
+    (1 << USISIE) |									// enable start condition interrupt
+    (1 << USIOIE) |									// enable overflow interrupt
+    (1 << USIWM1) | (1 << USIWM0) |					// set usi in two-wire mode, enable bit counter overflow hold
+    (1 << USICS1) | (0 << USICS0) | (0 << USICLK) |	// shift register clock source = external, positive edge, 4-bit counter source = external, both edges
+    (0 << USITC);									// don't toggle clock-port pin
 
-	USISR =
-		(1		<< USISIF)	|		// clear start condition flag
-		(1		<< USIOIF)	|		// clear overflow condition flag
-		(0		<< USIPF)	|		// don't clear stop condition flag
-		(1		<< USIDC)	|		// clear arbitration error flag
-		(0x00	<< USICNT0);		// set counter to "8" bits
+    USISR =
+    (1		<< USISIF)	|		// clear start condition flag
+    (1		<< USIOIF)	|		// clear overflow condition flag
+    (0		<< USIPF)	|		// don't clear stop condition flag
+    (1		<< USIDC)	|		// clear arbitration error flag
+    (0x00	<< USICNT0);		// set counter to "8" bits
 }
 
 ISR(USI_OVERFLOW_VECTOR)
 {
-	// bit shift register overflow condition occured
-	// scl forced low until overflow condition is cleared!
+  // bit shift register overflow condition occured
+  // scl forced low until overflow condition is cleared!
 
-	uint8_t data		= USIDR;
-	uint8_t set_counter = 0x00;		// send 8 bits (16 edges)
+  uint8_t data		= USIDR;
+  uint8_t set_counter = 0x00;		// send 8 bits (16 edges)
 
-	if(stats_enabled)
-		overflow_conditions_count++;
+  if(stats_enabled)
+    overflow_conditions_count++;
 
-again:
-	switch(of_state)
-	{
-		// start condition occured and succeed
-		// check address, if not OK, reset usi
-		// note: not using general call address
+  again:
+  switch(of_state)
+  {
+    // start condition occured and succeed
+    // check address, if not OK, reset usi
+    // note: not using general call address
 
-		case(of_state_check_address):
-		{
-			uint8_t address;
-			uint8_t direction;
+    case(of_state_check_address):
+    {
+      uint8_t address;
+      uint8_t direction;
 
-			direction	= data & 0x01;
-			address		= (data & 0xfe) >> 1;
+      direction	= data & 0x01;
+      address		= (data & 0xfe) >> 1;
 
-			if(address == slave_address)
-			{
-				ss_state = ss_state_address_selected;
+      if(address == slave_address)
+      {
+        ss_state = ss_state_address_selected;
 
-				if(direction)					// read request from master
-					of_state = of_state_send_data;
-				else							// write request from master
-					of_state = of_state_receive_data;
+        if(direction)					// read request from master
+          of_state = of_state_send_data;
+        else							// write request from master
+          of_state = of_state_receive_data;
 
-				USIDR		= 0x00;
-				set_counter = 0x0e;				// send 1 bit (2 edges)
-				set_sda_to_output();			// initiate send ack
-			}
-			else
-			{
-				USIDR		= 0x00;
-				set_counter = 0x00;
-				twi_reset_state();
-				ss_state = ss_state_address_not_selected;
-			}
+        USIDR		= 0x00;
+        set_counter = 0x0e;				// send 1 bit (2 edges)
+        set_sda_to_output();			// initiate send ack
+      }
+      else
+      {
+        USIDR		= 0x00;
+        set_counter = 0x00;
+        twi_reset_state();
+        ss_state = ss_state_address_not_selected;
+      }
 
-			break;
-		}
+      break;
+    }
 
-		// process read request from master
+    // process read request from master
 
-		case(of_state_send_data):
-		{
-			ss_state = ss_state_data_processed;
-			of_state = of_state_request_ack;
+    case(of_state_send_data):
+    {
+      ss_state = ss_state_data_processed;
+      of_state = of_state_request_ack;
 
-			if(output_buffer_current < output_buffer_length)
-				USIDR = output_buffer[output_buffer_current++];
-			else
-				USIDR = 0xfe;
+      if(output_buffer_current < output_buffer_length)
+        USIDR = output_buffer[output_buffer_current++];
+      else
+        USIDR = 0xfe;
 
-			set_counter = 0x00;
-			set_sda_to_output();				// initiate send data
+      set_counter = 0x00;
+      set_sda_to_output();				// initiate send data
 
-			break;
-		}
+      break;
+    }
 
-		// data sent to master, request ack (or nack) from master
+    // data sent to master, request ack (or nack) from master
 
-		case(of_state_request_ack):
-		{
-			of_state = of_state_check_ack;
+    case(of_state_request_ack):
+    {
+      of_state = of_state_check_ack;
 
-			USIDR		= 0x00;
-			set_counter = 0x0e;					//	receive 1 bit (2 edges)
-			set_sda_to_input();					//	initiate receive ack
+      USIDR		= 0x00;
+      set_counter = 0x0e;					//	receive 1 bit (2 edges)
+      set_sda_to_input();					//	initiate receive ack
 
-			break;
-		}
+      break;
+    }
 
-		// ack/nack from master received
+    // ack/nack from master received
 
-		case(of_state_check_ack):
-		{
-			if(data)	// if NACK, the master does not want more data
-			{
-				of_state = of_state_check_address;
-				set_counter = 0x00;
-				twi_reset();
-			}
-			else
-			{
-				of_state = of_state_send_data;
-				goto again;	// from here we just drop straight into state_send_data
-			}				// don't wait for another overflow interrupt
+    case(of_state_check_ack):
+    {
+      if(data)	// if NACK, the master does not want more data
+      {
+        of_state = of_state_check_address;
+        set_counter = 0x00;
+        twi_reset();
+      }
+      else
+      {
+        of_state = of_state_send_data;
+        goto again;	// from here we just drop straight into state_send_data
+      }				// don't wait for another overflow interrupt
 
-			break;
-		}
+      break;
+    }
 
-		// process write request from master
+    // process write request from master
 
-		case(of_state_receive_data):
-		{
-			ss_state = ss_state_data_processed;
+    case(of_state_receive_data):
+    {
+      ss_state = ss_state_data_processed;
 
-			of_state = of_state_store_data_and_send_ack;
+      of_state = of_state_store_data_and_send_ack;
 
-			set_counter = 0x00;					// receive 1 bit (2 edges)
-			set_sda_to_input();					// initiate receive data
+      set_counter = 0x00;					// receive 1 bit (2 edges)
+      set_sda_to_input();					// initiate receive data
 
-			break;
-		}
+      break;
+    }
 
-		// data received from master, store it and wait for more data
+    // data received from master, store it and wait for more data
 
-		case(of_state_store_data_and_send_ack):
-		{
-			of_state = of_state_receive_data;
+    case(of_state_store_data_and_send_ack):
+    {
+      of_state = of_state_receive_data;
 
-			if(input_buffer_length < (buffer_size - 1))
-				input_buffer[input_buffer_length++] = data;
+      if(input_buffer_length < (buffer_size - 1))
+        input_buffer[input_buffer_length++] = data;
 
-			USIDR		= 0x00;
-			set_counter = 0x0e;					// send 1 bit (2 edges)
-			set_sda_to_output();				// initiate send ack
+      USIDR		= 0x00;
+      set_counter = 0x0e;					// send 1 bit (2 edges)
+      set_sda_to_output();				// initiate send ack
 
-			break;
-		}
-	}
+      break;
+    }
+  }
 
-	USISR =
-		(0				<< USISIF)	|		// don't clear start condition flag
-		(1				<< USIOIF)	|		// clear overflow condition flag
-		(0				<< USIPF)	|		// don't clear stop condition flag
-		(1				<< USIDC)	|		// clear arbitration error flag
-		(set_counter	<< USICNT0);		// set counter to 8 or 1 bits
+  USISR =
+  (0				<< USISIF)	|		// don't clear start condition flag
+  (1				<< USIOIF)	|		// clear overflow condition flag
+  (0				<< USIPF)	|		// don't clear stop condition flag
+  (1				<< USIDC)	|		// clear arbitration error flag
+  (set_counter	<< USICNT0);		// set counter to 8 or 1 bits
 }
 
 void usi_twi_slave(uint8_t slave_address_in, uint8_t use_sleep,
-			void (*data_callback_in)(uint8_t buffer_size,
-			volatile uint8_t input_buffer_length, volatile const uint8_t *input_buffer,
-			volatile uint8_t *output_buffer_length, volatile uint8_t *output_buffer),
-			void (*idle_callback_in)(void))
+                   void (*data_callback_in)(uint8_t buffer_size,
+                                            volatile uint8_t input_buffer_length, volatile const uint8_t *input_buffer,
+                                            volatile uint8_t *output_buffer_length, volatile uint8_t *output_buffer),
+                   void (*idle_callback_in)(void))
 {
-	slave_address			= slave_address_in;
-	data_callback			= data_callback_in;
-	idle_callback			= idle_callback_in;
+  slave_address			= slave_address_in;
+  data_callback			= data_callback_in;
+  idle_callback			= idle_callback_in;
 
-	input_buffer_length		= 0;
-	output_buffer_length	= 0;
-	output_buffer_current	= 0;
-	ss_state				= ss_state_before_start;
+  input_buffer_length		= 0;
+  output_buffer_length	= 0;
+  output_buffer_current	= 0;
+  ss_state				= ss_state_before_start;
 
-	if(use_sleep)
-		set_sleep_mode(SLEEP_MODE_IDLE);
+  if(use_sleep)
+    set_sleep_mode(SLEEP_MODE_IDLE);
 
-	twi_init();
+  twi_init();
 
-	sei();
+  sei();
 
-	for(;;)
-	{
-		if(use_sleep && (ss_state == ss_state_before_start))
-			sleep_mode();
+  for(;;)
+  {
+    if(use_sleep && (ss_state == ss_state_before_start))
+      sleep_mode();
 
-		if(USISR & _BV(USIPF))
-		{
-			cli();
+    /*
+     * This library cannot detect repeated starts and will execute the callback only
+     * after a stop condition.
+     *
+     * Start processing when there is a byte in the input buffer
+     *
+     * WARNING: This means that we process data after one byte sent on I2C!
+     */
+    if((USISR & _BV(USIPF)) || (input_buffer_length > 0))
+    {
+      cli();
 
-			if(stats_enabled)
-				stop_conditions_count++;
+      if(stats_enabled)
+        stop_conditions_count++;
 
-			USISR |= _BV(USIPF);	// clear stop condition flag
+      USISR |= _BV(USIPF);	// clear stop condition flag
 
-			switch(ss_state)
-			{
-				case(ss_state_after_start):
-				{
-					twi_reset();
-					break;
-				}
+      switch(ss_state)
+      {
+        case(ss_state_after_start):
+        {
+          twi_reset();
+          break;
+        }
 
-				case(ss_state_data_processed):
-				{
-					if(stats_enabled)
-						local_frames_count++;
+        case(ss_state_data_processed):
+        {
+          if(stats_enabled)
+            local_frames_count++;
 
-					output_buffer_length	= 0;
-					output_buffer_current	= 0;
+          output_buffer_length	= 0;
+          output_buffer_current	= 0;
 
-					data_callback(buffer_size, input_buffer_length, input_buffer, &output_buffer_length, output_buffer);
+          data_callback(buffer_size, input_buffer_length, input_buffer, &output_buffer_length, output_buffer);
 
-					input_buffer_length		= 0;
+          input_buffer_length		= 0;
 
-					break;
-				}
+          break;
+        }
 
-			}
+      }
 
-			ss_state = ss_state_before_start;
+      ss_state = ss_state_before_start;
 
-			sei();
-		}
+      sei();
+    }
 
-		if(idle_callback)
-		{
-			idle_callback();
+    if(idle_callback)
+    {
+      idle_callback();
 
-			if(stats_enabled)
-				idle_call_count++;
-		}
-	}
+      if(stats_enabled)
+        idle_call_count++;
+    }
+  }
 }
 
 void usi_twi_enable_stats(uint8_t onoff)
 {
-	stats_enabled				= onoff;
-	start_conditions_count		= 0;
-	stop_conditions_count		= 0;
-	error_conditions_count		= 0;
-	overflow_conditions_count	= 0;
-	local_frames_count			= 0;
-	idle_call_count				= 0;
+  stats_enabled				= onoff;
+  start_conditions_count		= 0;
+  stop_conditions_count		= 0;
+  error_conditions_count		= 0;
+  overflow_conditions_count	= 0;
+  local_frames_count			= 0;
+  idle_call_count				= 0;
 }
 
 uint16_t usi_twi_stats_start_conditions(void)
 {
-	return(start_conditions_count);
+  return(start_conditions_count);
 }
 
 uint16_t usi_twi_stats_stop_conditions(void)
 {
-	return(stop_conditions_count);
+  return(stop_conditions_count);
 }
 
 uint16_t usi_twi_stats_error_conditions(void)
 {
-	return(error_conditions_count);
+  return(error_conditions_count);
 }
 
 uint16_t usi_twi_stats_overflow_conditions(void)
 {
-	return(overflow_conditions_count);
+  return(overflow_conditions_count);
 }
 
 uint16_t usi_twi_stats_local_frames(void)
 {
-	return(local_frames_count);
+  return(local_frames_count);
 }
 
 uint16_t usi_twi_stats_idle_calls(void)
 {
-	return(idle_call_count);
+  return(idle_call_count);
 }

--- a/manuellsteuerung/usitwislave.h
+++ b/manuellsteuerung/usitwislave.h
@@ -6,10 +6,10 @@
 #define	_USI_TWI_SLAVE_H_
 
 void		usi_twi_slave(uint8_t slave_address, uint8_t use_sleep,
-				void (*data_callback)(uint8_t buffer_size,
-				volatile uint8_t input_buffer_length, volatile const uint8_t *input_buffer,
-				volatile uint8_t *output_buffer_length, volatile uint8_t *output_buffer),
-				void (*idle_callback)(void));
+                      void (*data_callback)(uint8_t buffer_size,
+                                            volatile uint8_t input_buffer_length, volatile const uint8_t *input_buffer,
+                                            volatile uint8_t *output_buffer_length, volatile uint8_t *output_buffer),
+                    void (*idle_callback)(void));
 
 void		usi_twi_enable_stats(uint8_t onoff);
 uint16_t	usi_twi_stats_start_conditions(void);

--- a/manuellsteuerung/usitwislave_devices.h
+++ b/manuellsteuerung/usitwislave_devices.h
@@ -12,8 +12,8 @@
 #endif
 
 #if		defined(__AVR_ATtiny24__) | \
-		defined(__AVR_ATtiny44__) | \
-		defined(__AVR_ATtiny84__)
+defined(__AVR_ATtiny44__) | \
+defined(__AVR_ATtiny84__)
 #	define DDR_USI				DDRA
 #	define PORT_USI				PORTA
 #	define PIN_USI				PINA
@@ -25,8 +25,8 @@
 #endif
 
 #if		defined(__AVR_ATtiny25__) | \
-		defined(__AVR_ATtiny45__) | \
-		defined(__AVR_ATtiny85__)
+defined(__AVR_ATtiny45__) | \
+defined(__AVR_ATtiny85__)
 #	define DDR_USI				DDRB
 #	define PORT_USI				PORTB
 #	define PIN_USI				PINB
@@ -49,11 +49,11 @@
 #endif
 
 #if		defined(__AVR_ATtiny261__) | \
-		defined(__AVR_ATtiny261a__) | \
-		defined(__AVR_ATtiny461__) | \
-		defined(__AVR_ATtiny461a__) | \
-		defined(__AVR_ATtiny861__) | \
-		defined(__AVR_ATtiny861a__)
+defined(__AVR_ATtiny261a__) | \
+defined(__AVR_ATtiny461__) | \
+defined(__AVR_ATtiny461a__) | \
+defined(__AVR_ATtiny861__) | \
+defined(__AVR_ATtiny861a__)
 #	if		defined(USI_ON_PORT_A)
 #		define DDR_USI				DDRA
 #		define PORT_USI				PORTA
@@ -75,12 +75,12 @@
 #endif
 
 #if		defined(__AVR_ATmega165__) | \
-		defined(__AVR_ATmega325__) | \
-		defined(__AVR_ATmega3250__) | \
-		defined(__AVR_ATmega645__) | \
-		defined(__AVR_ATmega6450__) | \
-		defined(__AVR_ATmega329__) | \
-		defined(__AVR_ATmega3290__)
+defined(__AVR_ATmega325__) | \
+defined(__AVR_ATmega3250__) | \
+defined(__AVR_ATmega645__) | \
+defined(__AVR_ATmega6450__) | \
+defined(__AVR_ATmega329__) | \
+defined(__AVR_ATmega3290__)
 #	define DDR_USI				DDRE
 #	define PORT_USI				PORTE
 #	define PIN_USI				PINE

--- a/tuer-controller/usitwislave.c
+++ b/tuer-controller/usitwislave.c
@@ -11,32 +11,32 @@
 
 enum
 {
-	of_state_check_address,
-	of_state_send_data,
-	of_state_request_ack,
-	of_state_check_ack,
-	of_state_receive_data,
-	of_state_store_data_and_send_ack
+  of_state_check_address,
+  of_state_send_data,
+  of_state_request_ack,
+  of_state_check_ack,
+  of_state_receive_data,
+  of_state_store_data_and_send_ack
 } overflow_state_t;
 
 enum
 {
-	ss_state_before_start,
-	ss_state_after_start,
-	ss_state_address_selected,
-	ss_state_address_not_selected,
-	ss_state_data_processed
+  ss_state_before_start,
+  ss_state_after_start,
+  ss_state_address_selected,
+  ss_state_address_not_selected,
+  ss_state_data_processed
 } startstop_state_t;
 
 enum
 {
-	buffer_size = 32
+  buffer_size = 32
 };
 
 static void (*idle_callback)(void);
 static void	(*data_callback)(uint8_t buffer_size,
-						uint8_t volatile input_buffer_length, const volatile uint8_t *input_buffer,
-						uint8_t volatile *output_buffer_length, uint8_t volatile *output_buffer);
+                             uint8_t volatile input_buffer_length, const volatile uint8_t *input_buffer,
+                             uint8_t volatile *output_buffer_length, uint8_t volatile *output_buffer);
 
 static volatile	uint8_t of_state;
 static volatile uint8_t ss_state;
@@ -59,395 +59,403 @@ static volatile uint16_t	idle_call_count;
 
 static always_inline void set_sda_to_input(void)
 {
-	DDR_USI &= ~_BV(PORT_USI_SDA);
+  DDR_USI &= ~_BV(PORT_USI_SDA);
 }
 
 static always_inline void set_sda_to_output(void)
 {
-	DDR_USI |= _BV(PORT_USI_SDA);
+  DDR_USI |= _BV(PORT_USI_SDA);
 }
 
 static always_inline void set_scl_to_input(void)
 {
-	DDR_USI &= ~_BV(PORT_USI_SCL);
+  DDR_USI &= ~_BV(PORT_USI_SCL);
 }
 
 static always_inline void set_scl_to_output(void)
 {
-	DDR_USI |= _BV(PORT_USI_SCL);
+  DDR_USI |= _BV(PORT_USI_SCL);
 }
 
 static always_inline void set_sda_low(void)
 {
-	PORT_USI &= ~_BV(PORT_USI_SDA);
+  PORT_USI &= ~_BV(PORT_USI_SDA);
 }
 
 static always_inline void set_sda_high(void)
 {
-	PORT_USI |= _BV(PORT_USI_SDA);
+  PORT_USI |= _BV(PORT_USI_SDA);
 }
 
 static always_inline void set_scl_low(void)
 {
-	PORT_USI &= ~_BV(PORT_USI_SCL);
+  PORT_USI &= ~_BV(PORT_USI_SCL);
 }
 
 static always_inline void set_scl_high(void)
 {
-	PORT_USI |= _BV(PORT_USI_SCL);
+  PORT_USI |= _BV(PORT_USI_SCL);
 }
 
 static always_inline void twi_reset_state(void)
 {
-	USISR =
-		(1		<< USISIF)	|		// clear start condition flag
-		(1		<< USIOIF)	|		// clear overflow condition flag
-		(0		<< USIPF)	|		// don't clear stop condition flag
-		(1		<< USIDC)	|		// clear arbitration error flag
-		(0x00	<< USICNT0);		// set counter to "8" bits
+  USISR =
+  (1		<< USISIF)	|		// clear start condition flag
+  (1		<< USIOIF)	|		// clear overflow condition flag
+  (0		<< USIPF)	|		// don't clear stop condition flag
+  (1		<< USIDC)	|		// clear arbitration error flag
+  (0x00	<< USICNT0);		// set counter to "8" bits
 
-	USICR =
-		(1 << USISIE) |									// enable start condition interrupt
-		(0 << USIOIE) |									// disable overflow interrupt
-		(1 << USIWM1) | (0 << USIWM0) |					// set usi in two-wire mode, disable bit counter overflow hold
-		(1 << USICS1) | (0 << USICS0) | (0 << USICLK) |	// shift register clock source = external, positive edge, 4-bit counter source = external, both edges
-		(0 << USITC);									// don't toggle clock-port pin
+  USICR =
+  (1 << USISIE) |									// enable start condition interrupt
+  (0 << USIOIE) |									// disable overflow interrupt
+  (1 << USIWM1) | (0 << USIWM0) |					// set usi in two-wire mode, disable bit counter overflow hold
+  (1 << USICS1) | (0 << USICS0) | (0 << USICLK) |	// shift register clock source = external, positive edge, 4-bit counter source = external, both edges
+  (0 << USITC);									// don't toggle clock-port pin
 }
 
 static always_inline void twi_reset(void)
 {
-	// make sure no sda/scl remains pulled up or down
+  // make sure no sda/scl remains pulled up or down
 
-	set_sda_to_input();		//	deactivate internal pullup on sda/scl
-	set_sda_low();
-	set_scl_to_input();
-	set_scl_low();
+  set_sda_to_input();		//	deactivate internal pullup on sda/scl
+  set_sda_low();
+  set_scl_to_input();
+  set_scl_low();
 
-	set_sda_to_output();	//	release (set high) on sda/scl
-	set_sda_high();
-	set_sda_to_input();
-	set_scl_to_output();
-	set_scl_high();
+  set_sda_to_output();	//	release (set high) on sda/scl
+  set_sda_high();
+  set_sda_to_input();
+  set_scl_to_output();
+  set_scl_high();
 
-	twi_reset_state();
+  twi_reset_state();
 }
 
 static always_inline void twi_init(void)
 {
-#if defined(USIPP)
-#if  defined(USI_ON_PORT_A)
-	USIPP |= _BV(USIPOS);
-#else
-	USIPP &= ~_BV(USIPOS);
-# endif
-#endif
+  #if defined(USIPP)
+  #if  defined(USI_ON_PORT_A)
+  USIPP |= _BV(USIPOS);
+  #else
+  USIPP &= ~_BV(USIPOS);
+  # endif
+  #endif
 
-	twi_reset();
+  twi_reset();
 }
 
 ISR(USI_START_vect)
 {
-	set_sda_to_input();
+  set_sda_to_input();
 
-	// wait for SCL to go low to ensure the start condition has completed (the
-	// start detector will hold SCL low) - if a stop condition arises then leave
-	// the interrupt to prevent waiting forever - don't use USISR to test for stop
-	// condition as in Application Note AVR312 because the stop condition Flag is
-	// going to be set from the last TWI sequence
+  // wait for SCL to go low to ensure the start condition has completed (the
+  // start detector will hold SCL low) - if a stop condition arises then leave
+  // the interrupt to prevent waiting forever - don't use USISR to test for stop
+  // condition as in Application Note AVR312 because the stop condition Flag is
+  // going to be set from the last TWI sequence
 
-	while(!(PIN_USI & _BV(PIN_USI_SDA)) &&
-			(PIN_USI & _BV(PIN_USI_SCL)))
+  while(!(PIN_USI & _BV(PIN_USI_SDA)) &&
+    (PIN_USI & _BV(PIN_USI_SCL)))
 
-	// possible combinations
-	//	sda = low	scl = low		break	start condition
-	// 	sda = low	scl = high		loop
-	//	sda = high	scl = low		break	stop condition
-	//	sda = high	scl = high		break	stop condition
+    // possible combinations
+    //	sda = low	scl = low		break	start condition
+    // 	sda = low	scl = high		loop
+    //	sda = high	scl = low		break	stop condition
+    //	sda = high	scl = high		break	stop condition
 
-	if((PIN_USI & _BV(PIN_USI_SDA)))	// stop condition
-	{
-		twi_reset();
+    if((PIN_USI & _BV(PIN_USI_SDA)))	// stop condition
+    {
+      twi_reset();
 
-		if(stats_enabled)
-			error_conditions_count++;
-		return;
-	}
+      if(stats_enabled)
+        error_conditions_count++;
+      return;
+    }
 
-	if(stats_enabled)
-		start_conditions_count++;
+    if(stats_enabled)
+      start_conditions_count++;
 
-	of_state = of_state_check_address;
-	ss_state = ss_state_after_start;
+    of_state = of_state_check_address;
+    ss_state = ss_state_after_start;
 
-	USIDR = 0xff;
+    USIDR = 0xff;
 
-	USICR =
-		(1 << USISIE) |									// enable start condition interrupt
-		(1 << USIOIE) |									// enable overflow interrupt
-		(1 << USIWM1) | (1 << USIWM0) |					// set usi in two-wire mode, enable bit counter overflow hold
-		(1 << USICS1) | (0 << USICS0) | (0 << USICLK) |	// shift register clock source = external, positive edge, 4-bit counter source = external, both edges
-		(0 << USITC);									// don't toggle clock-port pin
+    USICR =
+    (1 << USISIE) |									// enable start condition interrupt
+    (1 << USIOIE) |									// enable overflow interrupt
+    (1 << USIWM1) | (1 << USIWM0) |					// set usi in two-wire mode, enable bit counter overflow hold
+    (1 << USICS1) | (0 << USICS0) | (0 << USICLK) |	// shift register clock source = external, positive edge, 4-bit counter source = external, both edges
+    (0 << USITC);									// don't toggle clock-port pin
 
-	USISR =
-		(1		<< USISIF)	|		// clear start condition flag
-		(1		<< USIOIF)	|		// clear overflow condition flag
-		(0		<< USIPF)	|		// don't clear stop condition flag
-		(1		<< USIDC)	|		// clear arbitration error flag
-		(0x00	<< USICNT0);		// set counter to "8" bits
+    USISR =
+    (1		<< USISIF)	|		// clear start condition flag
+    (1		<< USIOIF)	|		// clear overflow condition flag
+    (0		<< USIPF)	|		// don't clear stop condition flag
+    (1		<< USIDC)	|		// clear arbitration error flag
+    (0x00	<< USICNT0);		// set counter to "8" bits
 }
 
 ISR(USI_OVERFLOW_VECTOR)
 {
-	// bit shift register overflow condition occured
-	// scl forced low until overflow condition is cleared!
+  // bit shift register overflow condition occured
+  // scl forced low until overflow condition is cleared!
 
-	uint8_t data		= USIDR;
-	uint8_t set_counter = 0x00;		// send 8 bits (16 edges)
+  uint8_t data		= USIDR;
+  uint8_t set_counter = 0x00;		// send 8 bits (16 edges)
 
-	if(stats_enabled)
-		overflow_conditions_count++;
+  if(stats_enabled)
+    overflow_conditions_count++;
 
-again:
-	switch(of_state)
-	{
-		// start condition occured and succeed
-		// check address, if not OK, reset usi
-		// note: not using general call address
+  again:
+  switch(of_state)
+  {
+    // start condition occured and succeed
+    // check address, if not OK, reset usi
+    // note: not using general call address
 
-		case(of_state_check_address):
-		{
-			uint8_t address;
-			uint8_t direction;
+    case(of_state_check_address):
+    {
+      uint8_t address;
+      uint8_t direction;
 
-			direction	= data & 0x01;
-			address		= (data & 0xfe) >> 1;
+      direction	= data & 0x01;
+      address		= (data & 0xfe) >> 1;
 
-			if(address == slave_address)
-			{
-				ss_state = ss_state_address_selected;
+      if(address == slave_address)
+      {
+        ss_state = ss_state_address_selected;
 
-				if(direction)					// read request from master
-					of_state = of_state_send_data;
-				else							// write request from master
-					of_state = of_state_receive_data;
+        if(direction)					// read request from master
+          of_state = of_state_send_data;
+        else							// write request from master
+          of_state = of_state_receive_data;
 
-				USIDR		= 0x00;
-				set_counter = 0x0e;				// send 1 bit (2 edges)
-				set_sda_to_output();			// initiate send ack
-			}
-			else
-			{
-				USIDR		= 0x00;
-				set_counter = 0x00;
-				twi_reset_state();
-				ss_state = ss_state_address_not_selected;
-			}
+        USIDR		= 0x00;
+        set_counter = 0x0e;				// send 1 bit (2 edges)
+        set_sda_to_output();			// initiate send ack
+      }
+      else
+      {
+        USIDR		= 0x00;
+        set_counter = 0x00;
+        twi_reset_state();
+        ss_state = ss_state_address_not_selected;
+      }
 
-			break;
-		}
+      break;
+    }
 
-		// process read request from master
+    // process read request from master
 
-		case(of_state_send_data):
-		{
-			ss_state = ss_state_data_processed;
-			of_state = of_state_request_ack;
+    case(of_state_send_data):
+    {
+      ss_state = ss_state_data_processed;
+      of_state = of_state_request_ack;
 
-			if(output_buffer_current < output_buffer_length)
-				USIDR = output_buffer[output_buffer_current++];
-			else
-				USIDR = 0xfe;
+      if(output_buffer_current < output_buffer_length)
+        USIDR = output_buffer[output_buffer_current++];
+      else
+        USIDR = 0xfe;
 
-			set_counter = 0x00;
-			set_sda_to_output();				// initiate send data
+      set_counter = 0x00;
+      set_sda_to_output();				// initiate send data
 
-			break;
-		}
+      break;
+    }
 
-		// data sent to master, request ack (or nack) from master
+    // data sent to master, request ack (or nack) from master
 
-		case(of_state_request_ack):
-		{
-			of_state = of_state_check_ack;
+    case(of_state_request_ack):
+    {
+      of_state = of_state_check_ack;
 
-			USIDR		= 0x00;
-			set_counter = 0x0e;					//	receive 1 bit (2 edges)
-			set_sda_to_input();					//	initiate receive ack
+      USIDR		= 0x00;
+      set_counter = 0x0e;					//	receive 1 bit (2 edges)
+      set_sda_to_input();					//	initiate receive ack
 
-			break;
-		}
+      break;
+    }
 
-		// ack/nack from master received
+    // ack/nack from master received
 
-		case(of_state_check_ack):
-		{
-			if(data)	// if NACK, the master does not want more data
-			{
-				of_state = of_state_check_address;
-				set_counter = 0x00;
-				twi_reset();
-			}
-			else
-			{
-				of_state = of_state_send_data;
-				goto again;	// from here we just drop straight into state_send_data
-			}				// don't wait for another overflow interrupt
+    case(of_state_check_ack):
+    {
+      if(data)	// if NACK, the master does not want more data
+      {
+        of_state = of_state_check_address;
+        set_counter = 0x00;
+        twi_reset();
+      }
+      else
+      {
+        of_state = of_state_send_data;
+        goto again;	// from here we just drop straight into state_send_data
+      }				// don't wait for another overflow interrupt
 
-			break;
-		}
+      break;
+    }
 
-		// process write request from master
+    // process write request from master
 
-		case(of_state_receive_data):
-		{
-			ss_state = ss_state_data_processed;
+    case(of_state_receive_data):
+    {
+      ss_state = ss_state_data_processed;
 
-			of_state = of_state_store_data_and_send_ack;
+      of_state = of_state_store_data_and_send_ack;
 
-			set_counter = 0x00;					// receive 1 bit (2 edges)
-			set_sda_to_input();					// initiate receive data
+      set_counter = 0x00;					// receive 1 bit (2 edges)
+      set_sda_to_input();					// initiate receive data
 
-			break;
-		}
+      break;
+    }
 
-		// data received from master, store it and wait for more data
+    // data received from master, store it and wait for more data
 
-		case(of_state_store_data_and_send_ack):
-		{
-			of_state = of_state_receive_data;
+    case(of_state_store_data_and_send_ack):
+    {
+      of_state = of_state_receive_data;
 
-			if(input_buffer_length < (buffer_size - 1))
-				input_buffer[input_buffer_length++] = data;
+      if(input_buffer_length < (buffer_size - 1))
+        input_buffer[input_buffer_length++] = data;
 
-			USIDR		= 0x00;
-			set_counter = 0x0e;					// send 1 bit (2 edges)
-			set_sda_to_output();				// initiate send ack
+      USIDR		= 0x00;
+      set_counter = 0x0e;					// send 1 bit (2 edges)
+      set_sda_to_output();				// initiate send ack
 
-			break;
-		}
-	}
+      break;
+    }
+  }
 
-	USISR =
-		(0				<< USISIF)	|		// don't clear start condition flag
-		(1				<< USIOIF)	|		// clear overflow condition flag
-		(0				<< USIPF)	|		// don't clear stop condition flag
-		(1				<< USIDC)	|		// clear arbitration error flag
-		(set_counter	<< USICNT0);		// set counter to 8 or 1 bits
+  USISR =
+  (0				<< USISIF)	|		// don't clear start condition flag
+  (1				<< USIOIF)	|		// clear overflow condition flag
+  (0				<< USIPF)	|		// don't clear stop condition flag
+  (1				<< USIDC)	|		// clear arbitration error flag
+  (set_counter	<< USICNT0);		// set counter to 8 or 1 bits
 }
 
 void usi_twi_slave(uint8_t slave_address_in, uint8_t use_sleep,
-			void (*data_callback_in)(uint8_t buffer_size,
-			volatile uint8_t input_buffer_length, volatile const uint8_t *input_buffer,
-			volatile uint8_t *output_buffer_length, volatile uint8_t *output_buffer),
-			void (*idle_callback_in)(void))
+                   void (*data_callback_in)(uint8_t buffer_size,
+                                            volatile uint8_t input_buffer_length, volatile const uint8_t *input_buffer,
+                                            volatile uint8_t *output_buffer_length, volatile uint8_t *output_buffer),
+                   void (*idle_callback_in)(void))
 {
-	slave_address			= slave_address_in;
-	data_callback			= data_callback_in;
-	idle_callback			= idle_callback_in;
+  slave_address			= slave_address_in;
+  data_callback			= data_callback_in;
+  idle_callback			= idle_callback_in;
 
-	input_buffer_length		= 0;
-	output_buffer_length	= 0;
-	output_buffer_current	= 0;
-	ss_state				= ss_state_before_start;
+  input_buffer_length		= 0;
+  output_buffer_length	= 0;
+  output_buffer_current	= 0;
+  ss_state				= ss_state_before_start;
 
-	if(use_sleep)
-		set_sleep_mode(SLEEP_MODE_IDLE);
+  if(use_sleep)
+    set_sleep_mode(SLEEP_MODE_IDLE);
 
-	twi_init();
+  twi_init();
 
-	sei();
+  sei();
 
-	for(;;)
-	{
-		if(use_sleep && (ss_state == ss_state_before_start))
-			sleep_mode();
+  for(;;)
+  {
+    if(use_sleep && (ss_state == ss_state_before_start))
+      sleep_mode();
 
-		if(USISR & _BV(USIPF))
-		{
-			cli();
+    /*
+     * This library cannot detect repeated starts and will execute the callback only
+     * after a stop condition.
+     *
+     * Start processing when there is a byte in the input buffer
+     *
+     * WARNING: This means that we process data after one byte sent on I2C!
+     */
+    if((USISR & _BV(USIPF)) || (input_buffer_length > 0))
+    {
+      cli();
 
-			if(stats_enabled)
-				stop_conditions_count++;
+      if(stats_enabled)
+        stop_conditions_count++;
 
-			USISR |= _BV(USIPF);	// clear stop condition flag
+      USISR |= _BV(USIPF);	// clear stop condition flag
 
-			switch(ss_state)
-			{
-				case(ss_state_after_start):
-				{
-					twi_reset();
-					break;
-				}
+      switch(ss_state)
+      {
+        case(ss_state_after_start):
+        {
+          twi_reset();
+          break;
+        }
 
-				case(ss_state_data_processed):
-				{
-					if(stats_enabled)
-						local_frames_count++;
+        case(ss_state_data_processed):
+        {
+          if(stats_enabled)
+            local_frames_count++;
 
-					output_buffer_length	= 0;
-					output_buffer_current	= 0;
+          output_buffer_length	= 0;
+          output_buffer_current	= 0;
 
-					data_callback(buffer_size, input_buffer_length, input_buffer, &output_buffer_length, output_buffer);
+          data_callback(buffer_size, input_buffer_length, input_buffer, &output_buffer_length, output_buffer);
 
-					input_buffer_length		= 0;
+          input_buffer_length		= 0;
 
-					break;
-				}
+          break;
+        }
 
-			}
+      }
 
-			ss_state = ss_state_before_start;
+      ss_state = ss_state_before_start;
 
-			sei();
-		}
+      sei();
+    }
 
-		if(idle_callback)
-		{
-			idle_callback();
+    if(idle_callback)
+    {
+      idle_callback();
 
-			if(stats_enabled)
-				idle_call_count++;
-		}
-	}
+      if(stats_enabled)
+        idle_call_count++;
+    }
+  }
 }
 
 void usi_twi_enable_stats(uint8_t onoff)
 {
-	stats_enabled				= onoff;
-	start_conditions_count		= 0;
-	stop_conditions_count		= 0;
-	error_conditions_count		= 0;
-	overflow_conditions_count	= 0;
-	local_frames_count			= 0;
-	idle_call_count				= 0;
+  stats_enabled				= onoff;
+  start_conditions_count		= 0;
+  stop_conditions_count		= 0;
+  error_conditions_count		= 0;
+  overflow_conditions_count	= 0;
+  local_frames_count			= 0;
+  idle_call_count				= 0;
 }
 
 uint16_t usi_twi_stats_start_conditions(void)
 {
-	return(start_conditions_count);
+  return(start_conditions_count);
 }
 
 uint16_t usi_twi_stats_stop_conditions(void)
 {
-	return(stop_conditions_count);
+  return(stop_conditions_count);
 }
 
 uint16_t usi_twi_stats_error_conditions(void)
 {
-	return(error_conditions_count);
+  return(error_conditions_count);
 }
 
 uint16_t usi_twi_stats_overflow_conditions(void)
 {
-	return(overflow_conditions_count);
+  return(overflow_conditions_count);
 }
 
 uint16_t usi_twi_stats_local_frames(void)
 {
-	return(local_frames_count);
+  return(local_frames_count);
 }
 
 uint16_t usi_twi_stats_idle_calls(void)
 {
-	return(idle_call_count);
+  return(idle_call_count);
 }

--- a/tuer-controller/usitwislave.h
+++ b/tuer-controller/usitwislave.h
@@ -6,10 +6,10 @@
 #define	_USI_TWI_SLAVE_H_
 
 void		usi_twi_slave(uint8_t slave_address, uint8_t use_sleep,
-				void (*data_callback)(uint8_t buffer_size,
-				volatile uint8_t input_buffer_length, volatile const uint8_t *input_buffer,
-				volatile uint8_t *output_buffer_length, volatile uint8_t *output_buffer),
-				void (*idle_callback)(void));
+                      void (*data_callback)(uint8_t buffer_size,
+                                            volatile uint8_t input_buffer_length, volatile const uint8_t *input_buffer,
+                                            volatile uint8_t *output_buffer_length, volatile uint8_t *output_buffer),
+                    void (*idle_callback)(void));
 
 void		usi_twi_enable_stats(uint8_t onoff);
 uint16_t	usi_twi_stats_start_conditions(void);

--- a/tuer-controller/usitwislave_devices.h
+++ b/tuer-controller/usitwislave_devices.h
@@ -12,8 +12,8 @@
 #endif
 
 #if		defined(__AVR_ATtiny24__) | \
-		defined(__AVR_ATtiny44__) | \
-		defined(__AVR_ATtiny84__)
+defined(__AVR_ATtiny44__) | \
+defined(__AVR_ATtiny84__)
 #	define DDR_USI				DDRA
 #	define PORT_USI				PORTA
 #	define PIN_USI				PINA
@@ -25,8 +25,8 @@
 #endif
 
 #if		defined(__AVR_ATtiny25__) | \
-		defined(__AVR_ATtiny45__) | \
-		defined(__AVR_ATtiny85__)
+defined(__AVR_ATtiny45__) | \
+defined(__AVR_ATtiny85__)
 #	define DDR_USI				DDRB
 #	define PORT_USI				PORTB
 #	define PIN_USI				PINB
@@ -49,11 +49,11 @@
 #endif
 
 #if		defined(__AVR_ATtiny261__) | \
-		defined(__AVR_ATtiny261a__) | \
-		defined(__AVR_ATtiny461__) | \
-		defined(__AVR_ATtiny461a__) | \
-		defined(__AVR_ATtiny861__) | \
-		defined(__AVR_ATtiny861a__)
+defined(__AVR_ATtiny261a__) | \
+defined(__AVR_ATtiny461__) | \
+defined(__AVR_ATtiny461a__) | \
+defined(__AVR_ATtiny861__) | \
+defined(__AVR_ATtiny861a__)
 #	if		defined(USI_ON_PORT_A)
 #		define DDR_USI				DDRA
 #		define PORT_USI				PORTA
@@ -75,12 +75,12 @@
 #endif
 
 #if		defined(__AVR_ATmega165__) | \
-		defined(__AVR_ATmega325__) | \
-		defined(__AVR_ATmega3250__) | \
-		defined(__AVR_ATmega645__) | \
-		defined(__AVR_ATmega6450__) | \
-		defined(__AVR_ATmega329__) | \
-		defined(__AVR_ATmega3290__)
+defined(__AVR_ATmega325__) | \
+defined(__AVR_ATmega3250__) | \
+defined(__AVR_ATmega645__) | \
+defined(__AVR_ATmega6450__) | \
+defined(__AVR_ATmega329__) | \
+defined(__AVR_ATmega3290__)
 #	define DDR_USI				DDRE
 #	define PORT_USI				PORTE
 #	define PIN_USI				PINE


### PR DESCRIPTION
See https://www.netz39.de/wiki/projects:2020:i2c_foo for details.

tl;dr:

* Raspberry Pi 2 (or rather: up-to-date i2c drivers) implement repeated starts
* USITWI library uses stop condition, which is now missing, to determine when the callback should be executed
* There is no generic marker between sending and receiving bytes in a request
callback was only called after the complete request, thus the result was in the buffer for the next request and this weird shift happened

Current solution:

* We are only ever sending one request byte, so start processing as soon as there is one byte available.

The only generic marker would be to check the I2C direction bit, but that is sent last in the address, so we loose the time the bus takes to send 8 address bytes for sending. (This was the clever part in this library. Why the master is sending the 8 address bytes to get the result, the slave had time for processing.)

This solution works for our I3C bus, but in general has room for improvement outside the scope of this PR