### PR TITLE
Use jq to extract space status

### DIFF
--- a/raspberry/doorcontrol/door-with-spacestatus.sh
+++ b/raspberry/doorcontrol/door-with-spacestatus.sh
@@ -14,20 +14,9 @@ function wait_for_status {
 	done
 }
 
-function jsonval {
-	temp=$(echo $json | sed -e 's/\\\\\//\//g' -e 's/[{}]//g' \
-	                  | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' \
-	                  | sed -e 's/\"\:\"/\|/g' -e 's/[\,]/ /g' -e 's/\"//g' \
-	                  | grep -w $prop)
-	echo ${temp##*|}
-}
-
 function space_is_open {
 	json=$(curl -s https://spaceapi.n39.eu/json)
-	prop='open'
-	
-	st=$(jsonval)
-	isopen=$(echo "$st" | sed -e 's/.*open:\(.*\)/\1/')
+	isopen=$(echo $json | jq .state.open)
 	
 	echo "$isopen"
 }


### PR DESCRIPTION
Remove the old AWKward way of reading JSON data (which blocked other changes, as it could not handle a different ordering of the same structure) and replace it with jq.

For this version to work, `jq` must be installed.